### PR TITLE
feat: Add dig function

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,15 +29,15 @@ jobs:
         run: >
           echo ::set-output name=repo_owner::$(echo ${{ github.repository_owner }} |
           tr '[:upper:]' '[:lower:]')
-      - name: Docker Login
-        run: > 
-          echo ${{secrets.DOCKER_PASSWORD}} | 
-          docker login ghcr.io --username 
-          ${{ steps.get_repo_owner.outputs.repo_owner }} 
-          --password-stdin
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ steps.get_repo_owner.outputs.repo_owner }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
       - name: Publish functions
         run: >
-          OWNER="${{ steps.get_repo_owner.outputs.repo_owner }}" 
+          OWNER="${{ steps.get_repo_owner.outputs.repo_owner }}"
           TAG="latest"
           faas-cli publish
           --extra-tag ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ curl http://127.0.0.1:8080 -d "-c 5 -n 1000 https://your-service.com/"
 
 * `alpine` - a base for running built-in bash or busybox commands like `env` (use it to debug headers) or `wc -l` to count text within a body
 * `curl` - debug outgoing networking or internal services
+* `dig` - debug DNS resolution from inside your cluster
 * `figlet` - print ASCII logso
 * `hey` - run a load-test against a HTTP API, website, or function with [hey](https://github.com/rakyll/hey)
 * `nmap` - scan a network range

--- a/dig/Dockerfile
+++ b/dig/Dockerfile
@@ -1,0 +1,40 @@
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.13
+
+RUN mkdir -p /home/app
+
+RUN apk add --no-cache bind-tools
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+# Add non root user
+RUN addgroup -S app && adduser app -S -G app
+RUN chown app /home/app
+
+WORKDIR /home/app
+
+USER app
+
+COPY --chown=app:app dig.sh .
+RUN chmod +x dig.sh
+
+# customize the json key name for the success responses
+ENV response_key="ip_address"
+
+# configure of-watchdog
+# https://github.com/openfaas/of-watchdog#configuration
+ENV fprocess="/home/app/dig.sh"
+ENV mode="streaming"
+ENV content_type="application/json"
+ENV suppress_lock="false"
+ENV prefix_logs="false"
+# Set to true to see request in function logs
+ENV write_debug="false"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]

--- a/dig/dig.sh
+++ b/dig/dig.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+
+# write log message to stderr
+log() {
+    echo "$@" 1>&2;
+}
+
+IFS='' read -d '' -r request
+response=$(dig "$request" +short 2>&1)
+status=$?
+
+log "request=\"$request\" response=\"$response\" content_type=\"$content_type\""
+
+if [ "$content_type" = "application/json" ]; then
+    key="error"
+    if [ $status -eq 0 ]; then
+        key="${response_key:-response}"
+    fi
+
+    echo "{\"$key\": \"$response\"}"
+else
+    echo "$response"
+fi

--- a/stack.yml
+++ b/stack.yml
@@ -12,6 +12,11 @@ functions:
     handler: ./curl
     image: ghcr.io/${OWNER:-openfaas}/curl:${TAG:-latest}
 
+  dig:
+    lang: dockerfile
+    handler: ./dig
+    image: ghcr.io/${OWNER:-openfaas}/dig:${TAG:-latest}
+
   shasum:
     lang: dockerfile
     handler: ./shasum


### PR DESCRIPTION
**What**
- Add a `dig` function that can be used to verify DNS resultion inside a
  cluster. The function is implemented as a small bash script that
  invokes `dig` and then returns the result as JSON or text, depending
  on an ENV configuration. This function can also be used to demonstrate
  how to lightly wrap the CLI tool and provide some logging to stderr

To test

```sh
$ faas-cli build --filter dig
$ docker run --name digtest --rm -p 8080:8080 ghcr.io/openfaas/dig:latest
$ curl localhost:8080 -d "google.com"
{"ip_address": "172.217.23.110"}
$ docker kill digtest
```
Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>