### PR TITLE
fix executable file name

### DIFF
--- a/nslookup/Dockerfile
+++ b/nslookup/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /home/app
 
 USER app
 
-ENV fprocess="xargs bind-tools"
+ENV fprocess="xargs nslookup"
 
 ENV write_debug="false"
 


### PR DESCRIPTION
The nslookup function throws an error because the executable name is incorrect:

```
Internal Server Error
exit status 127
xargs: bind-tools: No such file or directory
```