### PR TITLE
Pretty print json payloads in the printer function.

### DIFF
--- a/printer/handler.go
+++ b/printer/handler.go
@@ -1,20 +1,53 @@
 package function
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strconv"
 )
+
+func formatJSON(data []byte) ([]byte, error) {
+	var out bytes.Buffer
+
+	if err := json.Indent(&out, data, "", "    "); err != nil {
+		return data, err
+	}
+
+	return out.Bytes(), nil
+}
+
+func printRaw() bool {
+	val := os.Getenv("RAW")
+	raw, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+	return raw
+}
 
 func Handle(w http.ResponseWriter, r *http.Request) {
 	var input []byte
 
+	contentType := r.Header.Get("content-type")
 	if r.Body != nil {
 		defer r.Body.Close()
 
 		body, _ := io.ReadAll(r.Body)
 
-		input = body
+		if !printRaw() && contentType == "application/json" {
+			var err error
+			input, err = formatJSON(body)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("failed to format JSON body: %s", err), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			input = body
+		}
 	}
 
 	for k, v := range r.Header {


### PR DESCRIPTION
## Description

Update the printer function to support pretty printing of json payloads.

If the env variable `RAW=true` it will print the raw payload.

## How has this been tested
Deployed the printer function:
```bash
SERVER=ttl.sh OWNER=welteki faas-cli up --filter printer
```

Invoked the function with a json payload:
```bash
curl -i $OPENFAAS_URL/function/printer \
  -d '{ "foo": "bar", "greeting": "hello" }' \
  -H 'Content-Type: application/json'
```

Verified the logs to see the payload was printed correctly:
```
2023-12-15T17:26:00Z User-Agent=[curl/7.81.0]
2023-12-15T17:26:00Z Accept-Encoding=[gzip]
2023-12-15T17:26:00Z X-Forwarded-Host=[gw.exit.welteki.dev]
2023-12-15T17:26:00Z X-Forwarded-Proto=[https]
2023-12-15T17:26:00Z X-Start-Time=[1702661160444470811]
2023-12-15T17:26:00Z Accept=[*/*]
2023-12-15T17:26:00Z X-Forwarded-For=[94.105.108.156, 127.0.0.1]
2023-12-15T17:26:00Z X-Forwarded-Uri=[/function/printer]
2023-12-15T17:26:00Z Content-Type=[application/json]
2023-12-15T17:26:00Z X-Call-Id=[dc321b80-f5d8-4d9f-adea-5f23823abf07]
2023-12-15T17:26:00Z X-Inlets-Id=[303f46d3442a456892f74d55d51debb9]
2023-12-15T17:26:00Z 
2023-12-15T17:26:00Z {
2023-12-15T17:26:00Z     "foo": "bar",
2023-12-15T17:26:00Z     "greeting": "hello"
2023-12-15T17:26:00Z }
```

Verified the raw payload is printed when the env variable `RAW=true`
Verified the raw payload is printed if the request does not set the header `Content-Type: application/json`:
```bash
curl -i $OPENFAAS_URL/function/printer \
  -d '{ "foo": "bar", "greeting": "hello" }'
```