### PR TITLE
Add nvidia-smi function

### DIFF
--- a/nvidia-smi/Dockerfile
+++ b/nvidia-smi/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/openfaas/classic-watchdog:0.3.2 AS watchdog
+
+FROM ubuntu:24.04
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+USER 1000
+
+ENV fprocess="nvidia-smi"
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+CMD ["fwatchdog"]

--- a/stack.yml
+++ b/stack.yml
@@ -100,11 +100,14 @@ functions:
     lang: golang-middleware
     handler: ./markdown
     image: ${SERVER:-ghcr.io}/${OWNER:-openfaas}/markdown-fn:${TAG:-latest}
+  
+  nvidia-smi:
+    lang: dockerfile
+    handler: ./nvidia-smi
+    image: ${SERVER:-ghcr.io}/${OWNER:-openfaas}/nvidia-smi:${TAG:-latest}
 
 
 configuration:
   templates:
     - name: golang-middleware
       source: https://github.com/openfaas/golang-http-template
-
-


### PR DESCRIPTION
## Description

Add nvidi-smi function to the store.

Invoking the function returns the NVIDIA System Management Interface (nvidia-smi) info.

## How has this been tested

Ran the function locally using docker with the `nvidia` container runtime.

```sh
 docker run --rm -it -p 8080:8080 \
  --runtime=nvidia \
  --gpus all \
  ghcr.io/openfaas/nvidia-smi:latest 
```

```sh
curl -i 127.0.0.1:8080
HTTP/1.1 200 OK
X-Duration-Seconds: 0.044398
Date: Wed, 22 Jan 2025 15:44:22 GMT
Content-Length: 1778
Content-Type: text/plain; charset=utf-8

Wed Jan 22 15:44:22 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce GT 1030         On  |   00000000:01:00.0 Off |                  N/A |
| 35%   26C    P8             N/A /   19W |       2MiB /   2048MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
```

