### PR TITLE
Use golang-middleware function for sleep function

### DIFF
--- a/sleep/go.mod
+++ b/sleep/go.mod
@@ -1,0 +1,3 @@
+module handler/function
+
+go 1.18

--- a/stack.yml
+++ b/stack.yml
@@ -69,12 +69,11 @@ functions:
       com.openfaas.ui.ext: "mp4"
 
   sleep:
-    lang: go
+    lang: golang-middleware
     handler: ./sleep
     image: ${SERVER:-ghcr.io}/${OWNER:-openfaas}/sleep:${TAG:-latest}
     environment:
       sleep_duration: 2s
-      combine_output: false
 
   haveibeenpwned:
     lang: go
@@ -100,12 +99,11 @@ functions:
     lang: golang-middleware
     handler: ./markdown
     image: ${SERVER:-ghcr.io}/${OWNER:-openfaas}/markdown-fn:${TAG:-latest}
-  
+
   nvidia-smi:
     lang: dockerfile
     handler: ./nvidia-smi
     image: ${SERVER:-ghcr.io}/${OWNER:-openfaas}/nvidia-smi:${TAG:-latest}
-
 
 configuration:
   templates:


### PR DESCRIPTION
## Description

Convert the sleep function to use the golang-middleware template and of-watchdog instead of the deprecated go template.

## Motivation and context

Switch to latest golang template and of-watchdog.

## How has this been tested

Function has been tested locally with `faas-cli local-run`